### PR TITLE
add qos=2 support in Subscript

### DIFF
--- a/SAM/MQTT/sam_mqtt.php
+++ b/SAM/MQTT/sam_mqtt.php
@@ -273,6 +273,7 @@ class SAMConnection_MQTT {
                             $this->errno = 303;
                             $this->error = 'Receive request failed, message format invalid!';
                             $rc = false;
+                            break;
                         } else {
                             if ($this->debug) t('SAMConnection_MQTT.Receive() topic='.$topic);
                             $len -= (strlen($topic) + 2);
@@ -305,6 +306,7 @@ class SAMConnection_MQTT {
                         $this->errno = 303;
                         $this->error = 'Receive request failed, received message too short! No topic data';
                         $rc = false;
+                        break;
                     }
                 }
                 else if ($hdr['mtype'] == $this->operations['MQTT_PUBREL']) {
@@ -318,6 +320,7 @@ class SAMConnection_MQTT {
                         $this->errno = 302;
                         $this->error = 'Send request failed!';
                         $rc = false;
+                        break;
                     } else {
                         
                         $variable = pack('n', $mid);
@@ -330,6 +333,7 @@ class SAMConnection_MQTT {
                 else {
                     if ($this->debug) t('!!! SAMConnection_MQTT.Receive() Receive failed response mtype = '.$hdr["mtype"]);
                     $rc = false;
+                    break;
                 }
             }
         }
@@ -562,6 +566,7 @@ class SAMConnection_MQTT {
                     $this->errno = 301;
                     $this->error = 'Subscribe request failed, incorrect length response ($len) received!';
                     $rc = false;
+                    break;
                 }
             }
             else if ($hdr['mtype'] == $this->operations['MQTT_PUBLISH']) {
@@ -573,6 +578,7 @@ class SAMConnection_MQTT {
                             $this->errno = 303;
                             $this->error = 'Receive request failed, message format invalid!';
                             $rc = false;
+                            break;
                         } else {
                             if ($this->debug) t('SAMConnection_MQTT.Receive() topic='.$topic);
                             $len -= (strlen($topic) + 2);
@@ -607,6 +613,7 @@ class SAMConnection_MQTT {
                         $this->errno = 303;
                         $this->error = 'Subscript request failed, received message too short! No topic data';
                         $rc = false;
+                        break;
                     }
                 }
                 else if ($hdr['mtype'] == $this->operations['MQTT_PUBREL']) {
@@ -620,6 +627,7 @@ class SAMConnection_MQTT {
                         $this->errno = 302;
                         $this->error = 'Send request failed!';
                         $rc = false;
+                        break;
                     } else {
                         $variable = pack('n', $mid);
                         $msg = $this->fixed_header("MQTT_PUBCOMP").$this->remaining_length(strlen($variable)).$variable;
@@ -630,16 +638,17 @@ class SAMConnection_MQTT {
                 } 
                 else {
                     if ($this->debug) t('SAMConnection_MQTT.Subscribe() subscribe failed response mtype = '.$hdr['mtype']);
-                $rc = false;
+                    $rc = false;
+                    break;
+                }
             }
         }
-    }
 
-    if ($this->debug) var_dump($subrc);//x("SAMConnection_MQTT.Subscribe() rc=$rc");
-    if($subrc)
-        return $subrc;
-    else
-        return false;
+        if ($this->debug) var_dump($subrc);//x("SAMConnection_MQTT.Subscribe() rc=$rc");
+        if($subrc)
+            return $subrc;
+        else
+            return false;
   }
 
   /* ---------------------------------

--- a/SAM/php_sam.php
+++ b/SAM/php_sam.php
@@ -38,7 +38,7 @@ define('SAM_MQTT', 'mqtt');
     SAMConnection
    --------------------------------- */
 class SAMConnection {
- // var $debug = true;
+//  var $debug = true;
   var $debug = false;
 
   var $errno = 0;
@@ -276,7 +276,7 @@ class SAMConnection {
         }
     }
 
-    if ($this->debug) x("SAMConnection.Receive() rc=$rc");
+    if ($this->debug) var_dump($rc);//x("SAMConnection.Receive() rc=$rc");
     return $rc;
   }
 
@@ -396,7 +396,7 @@ class SAMConnection {
         }
     }
 
-    if ($this->debug) x("SAMConnection.Subscribe() rc=$rc");
+    if ($this->debug) var_dump($rc);//x("SAMConnection.Subscribe() rc=$rc");
     return $rc;
   }
 

--- a/receive_mqtt.php
+++ b/receive_mqtt.php
@@ -5,15 +5,14 @@
 
 require('SAM/php_sam.php');
 
-//create a new connection object，创建一个新的连接对象
+//create a new connection object
 $conn = new SAMConnection();
 //$conn->SetDebug(true);
-//start initialise the connection，开始初始化连接
+//start initialise the connection
 $conn->connect(SAM_MQTT, array(SAM_HOST => '127.0.0.1',
                                SAM_PORT => 1883, 
                                SAM_MQTT_CLEANSTART => false ));     
 
-//接收通知
 $sid=$conn->Subscribe('topic://xxx', array(SAM_MQTT_QOS => 2, SAM_MQTT_SUBID => "yyxyy"));
 if($sid)
 {

--- a/receive_mqtt.php
+++ b/receive_mqtt.php
@@ -1,0 +1,26 @@
+<?php
+
+//this test simulate the request like this:  mosquitto_sub -h 127.0.0.1 -t xxx -i yyxyy -c -q 2
+`mosquitto_pub -h 127.0.0.1 -t xxx -m hihi64 -q 2 `;  //first send a qos2 message, it would be cached by mosquitto 
+
+require('SAM/php_sam.php');
+
+//create a new connection object，创建一个新的连接对象
+$conn = new SAMConnection();
+//$conn->SetDebug(true);
+//start initialise the connection，开始初始化连接
+$conn->connect(SAM_MQTT, array(SAM_HOST => '127.0.0.1',
+                               SAM_PORT => 1883, 
+                               SAM_MQTT_CLEANSTART => false ));     
+
+//接收通知
+$sid=$conn->Subscribe('topic://xxx', array(SAM_MQTT_QOS => 2, SAM_MQTT_SUBID => "yyxyy"));
+if($sid)
+{
+    do{
+        $rc=$conn->Receive($sid, array(SAM_MQTT_QOS => 2, SAM_WAIT => 5000));
+        var_dump($rc);
+    }while($rc);
+}
+$conn->disconnect();
+?>


### PR DESCRIPTION
and some other minor bugfix, such as should use array_key_exists instead of in_array, and use $hdr['mtype'] instead of $mtype. 
queue up all messages received in Subscript and return them in subsequence Receive. I think this would be the easiest way to cope with qos 2 messages that were sent before mqtt clients connected to server.
